### PR TITLE
Fix Issue #13 multiple service calls

### DIFF
--- a/compact-cover-control-card.js
+++ b/compact-cover-control-card.js
@@ -77,7 +77,7 @@ const rt=(t,e)=>"method"===e.kind&&e.descriptor&&!("value"in e.descriptor)?{...e
           min="${ht.SLIDER_MIN}"
           max="${ht.SLIDER_MAX}"
           .value=${s}
-          @input=${e=>this._handleSliderChange(e,t.entity)}
+          @change=${e=>this._handleSliderChange(e,t.entity)}
           class="slider"
           style="
             direction: ${this.config.invert_percentage?"rtl":"ltr"};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compact-cover-control-card",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Custom card for controlling covers in Home Assistant",
   "keywords": [
     "home-assistant",

--- a/src/compact-cover-control-card.ts
+++ b/src/compact-cover-control-card.ts
@@ -173,7 +173,7 @@ export class CompactCoverControlCard extends LitElement {
           min="${CompactCoverControlCard.SLIDER_MIN}"
           max="${CompactCoverControlCard.SLIDER_MAX}"
           .value=${currentPosition}
-          @input=${(e: Event) => this._handleSliderChange(e, cover.entity)}
+          @change=${(e: Event) => this._handleSliderChange(e, cover.entity)}
           class="slider"
           style="
             direction: ${this.config.invert_percentage ? 'rtl' : 'ltr'};


### PR DESCRIPTION
## Fix: Prevent excessive service calls during slider interaction (Closes #13 )

### Problem
Dragging the slider triggered multiple service calls (one per pixel), causing covers to queue and execute all intermediate positions instead of moving directly to the target.

### Solution
Changed slider event from `@input` to `@change`, so the service call only fires when the user releases the slider.
